### PR TITLE
Build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ jobs:
       script:
         - "./cd/build.sh"
     - stage: quality
-      script: "./cd/ws-it.sh"
-    - script: "./cd/sonar.sh"
+      script: "./cd/sonar.sh"
 
 env:
   global:

--- a/cd/build.sh
+++ b/cd/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
-    mvn deploy -P sign,docker,docker-it,!ws-it,build-extras
+    mvn deploy -P sign,docker,docker-it,build-extras
 else
-    mvn install -P docker,docker-it,!ws-it,build-extras
+    mvn install -P docker,docker-it,build-extras
 fi

--- a/cd/ws-it.sh
+++ b/cd/ws-it.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-mvn -Dmaven.test.skip=true verify -P ws-it

--- a/pom.xml
+++ b/pom.xml
@@ -260,57 +260,6 @@
             </build>
         </profile>
         <profile>
-            <id>ws-it</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>io.thorntail</groupId>
-                            <artifactId>thorntail-maven-plugin</artifactId>
-                            <executions>
-                                <execution>
-                                    <id>start</id>
-                                    <goals>
-                                        <goal>start</goal>
-                                    </goals>
-                                    <phase>pre-integration-test</phase>
-                                </execution>
-                                <execution>
-                                    <id>stop</id>
-                                    <goals>
-                                        <goal>stop</goal>
-                                    </goals>
-                                    <phase>post-integration-test</phase>
-                                </execution>
-                            </executions>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-failsafe-plugin</artifactId>
-                            <configuration>
-                                <systemProperties>
-                                    <sleep.before>0</sleep.before>
-                                    <it.baseuri>http://127.0.0.1/</it.baseuri>
-                                    <it.port>${swarm.http.port}</it.port>
-                                </systemProperties>
-                            </configuration>
-                            <executions>
-                                <execution>
-                                    <goals>
-                                        <goal>integration-test</goal>
-                                        <goal>verify</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
             <id>docker-it</id>
             <build>
                 <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
         <file.hollow-jar>${project.build.finalName}-hollow-thorntail.jar</file.hollow-jar>
         <file.hollow-app>${project.build.finalName}.war</file.hollow-app>
         <docker.repository>postremus</docker.repository>
-        <debugPort>5005</debugPort>
         <swarm.http.port>8080</swarm.http.port>
         <docker.published.port>8081</docker.published.port>
 
@@ -238,27 +237,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>debug</id>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>io.thorntail</groupId>
-                            <artifactId>thorntail-maven-plugin</artifactId>
-                            <version>${version.thorntail}</version>
-                            <configuration>
-                                <debugPort>${debugPort}</debugPort>
-                                <properties>
-                                    <swarm.debug.port>${debugPort}</swarm.debug.port>
-                                </properties>
-                                <hollow>true</hollow>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
         <profile>
             <id>docker-it</id>
             <build>


### PR DESCRIPTION
Remove debug profile. For debugging, just use a jar application configuration

ws-it removed. Integration testing does not need to be done multiple times